### PR TITLE
Make trello.css link relative to fix current 404 status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@
 2. Go to [trello.com](https://trello.com).
 3. Click Stylish extension icon.
 4. Click "Create style for trello.com/" link.
-5. Copy and paste code from [dist/trello.css](https://raw.githubusercontent.com/gambala/trello/master/dist/trello.css) to Stylish textarea.
+5. Copy and paste code from [dist/trello.css](/dist/trello.css) to Stylish textarea.
 6. Save your theme.


### PR DESCRIPTION
Repository's new name probably made broken the link to .css file, so I decided to hotfix that.

I made relative link which allows us not to think about forked repositories links and the branch names. 

So if you fork the repo, link will be pointed onto forked one' css (test it on my branch at https://github.com/Mayurifag/trello-feels-good/tree/fix-404-link-at-readme — new github username / probably another repository name / new branch)

P.S. It also has less text :)

Other considerations about userstyles, whose I wanted to commit (probably via another PR), but not sure if maintainer agrees:
 
* Change the extension to Stylus or add it as an alternative due to [privacy related issues after userstyles.org was bought](https://github.com/openstyles/stylus/wiki/FAQ#what-are-the-main-differences-and-improvements-over-the-original-stylish-add-on)
* Add links to Firefox-based extensions on addons.mozilla.org
 
 If dist css file have had something like that...
 
 ```
 /* ==UserStyle==
@name         Example UserCSS style
@namespace    github.com/openstyles/stylus
@version      1.0.0
@license      unlicense
@preprocessor default
@var color link-color "Link Color" red
==/UserStyle== */
```
 
... I'd request to change original extension from `.css` to `.user.css` or `.user.styl` — so it would be installed onto Stylus [via much less clicks](https://github.com/openstyles/stylus/wiki/UserCSS#usercss-file). Another way would be to have copy-pasted yet another duplicated file, but I wont like this approach.